### PR TITLE
Add natural language orchestration and slash command shortcuts

### DIFF
--- a/codex-rs/cli/src/ask_cmd.rs
+++ b/codex-rs/cli/src/ask_cmd.rs
@@ -1,7 +1,9 @@
 use anyhow::Context;
 use anyhow::Result;
 use codex_common::CliConfigOverrides;
+use codex_core::agent_interpreter::AgentAction;
 use codex_core::agent_interpreter::AgentInterpreter;
+use codex_core::agent_interpreter::WebhookServiceKind;
 use codex_core::agents::AgentAliases;
 use std::path::PathBuf;
 
@@ -56,7 +58,28 @@ pub async fn run_natural_language_agent(
         .context("Failed to interpret natural language command")?;
 
     println!("🧠 Interpreted command:");
-    println!("   Agent: {}", invocation.agent_name);
+    match &invocation.action {
+        AgentAction::Delegate { agent } => {
+            println!("   Action: delegate to agent '{agent}'");
+        }
+        AgentAction::AutoOrchestrate => {
+            println!("   Action: auto orchestrate multi-agent session");
+        }
+        AgentAction::DeepResearch {
+            use_gemini,
+            use_mcp,
+        } => {
+            let gemini = if *use_gemini { " (Gemini)" } else { "" };
+            let mcp = if *use_mcp { " via MCP" } else { "" };
+            println!("   Action: deep research{gemini}{mcp}");
+        }
+        AgentAction::TriggerWebhook { service } => {
+            println!("   Action: trigger {:?} webhook", service);
+        }
+        AgentAction::ListMcpTools => {
+            println!("   Action: list configured MCP tools");
+        }
+    }
     println!("   Confidence: {:.0}%", invocation.confidence * 100.0);
     if !invocation.parameters.is_empty() {
         println!("   Parameters:");
@@ -66,16 +89,118 @@ pub async fn run_natural_language_agent(
     }
     println!("   Task: {}\n", invocation.goal);
 
-    crate::delegate_cmd::run_delegate_command(
-        config_overrides,
-        invocation.agent_name,
-        Some(invocation.goal),
-        scope,
-        budget,
-        None, // deadline
-        out,
-    )
-    .await
+    let action = invocation.action.clone();
+    match action {
+        AgentAction::Delegate { agent } => {
+            crate::delegate_cmd::run_delegate_command(
+                config_overrides,
+                agent,
+                Some(invocation.goal),
+                scope,
+                budget,
+                None,
+                out,
+            )
+            .await
+        }
+        AgentAction::AutoOrchestrate => {
+            let agents = parse_agents(invocation.parameters.get("agents"));
+            let rounds = parse_usize_param(&invocation.parameters, "rounds").unwrap_or(3);
+            let top_k = parse_usize_param(&invocation.parameters, "top_k").unwrap_or(2);
+            let improvement_threshold = parse_f64_param(&invocation.parameters, "threshold");
+            let max_risk = parse_f64_param(&invocation.parameters, "max_risk");
+
+            crate::pair_program_cmd::run_pair_program_command(
+                config_overrides,
+                invocation.goal,
+                agents,
+                rounds,
+                top_k,
+                improvement_threshold,
+                max_risk,
+                out,
+            )
+            .await
+        }
+        AgentAction::DeepResearch {
+            use_gemini,
+            use_mcp,
+        } => {
+            let topic = invocation
+                .parameters
+                .get("topic")
+                .cloned()
+                .unwrap_or_else(|| invocation.goal.clone());
+            let depth = parse_u8_param(&invocation.parameters, "depth").unwrap_or(3);
+            let breadth = parse_u8_param(&invocation.parameters, "breadth").unwrap_or(3);
+            let budget_tokens =
+                parse_usize_param(&invocation.parameters, "budget").unwrap_or(80_000);
+            let mcp_url = invocation.parameters.get("mcp_url").cloned();
+
+            crate::research_cmd::run_research_command(
+                topic,
+                depth,
+                breadth,
+                budget_tokens,
+                true,
+                mcp_url,
+                false,
+                out,
+                use_gemini,
+                use_mcp,
+            )
+            .await
+        }
+        AgentAction::TriggerWebhook { service } => match service {
+            WebhookServiceKind::Slack => {
+                use crate::webhook_cmd::SlackArgs;
+                use crate::webhook_cmd::WebhookCli;
+                use crate::webhook_cmd::WebhookSubcommand;
+
+                let text = invocation
+                    .parameters
+                    .get("message")
+                    .cloned()
+                    .unwrap_or_else(|| invocation.goal.clone());
+                let channel = invocation
+                    .parameters
+                    .get("channel")
+                    .and_then(|value| normalize_channel(value));
+
+                let slack_args = SlackArgs {
+                    text,
+                    channel,
+                    data: None,
+                };
+
+                crate::webhook_cmd::run(WebhookCli {
+                    config_overrides,
+                    subcommand: WebhookSubcommand::Slack(slack_args),
+                })
+                .await
+            }
+            WebhookServiceKind::Github => {
+                println!("ℹ️ GitHub webhooks require an endpoint and JSON payload. Use `codex webhook github --endpoint <path> --data '<json>'` for full control.");
+                Ok(())
+            }
+            WebhookServiceKind::Custom => {
+                println!("ℹ️ Custom webhooks require a URL and payload. Use `codex webhook custom --url <URL> --data '<json>'` to send a request.");
+                Ok(())
+            }
+        },
+        AgentAction::ListMcpTools => {
+            use crate::mcp_cmd::ListArgs;
+            use crate::mcp_cmd::McpCli;
+            use crate::mcp_cmd::McpSubcommand;
+
+            McpCli {
+                config_overrides,
+                subcommand: McpSubcommand::List(ListArgs { json: false }),
+            }
+            .run()
+            .await
+        }
+    }
 }
 
 /// Shortcut command that automatically selects the appropriate agent
@@ -103,4 +228,43 @@ pub async fn run_shortcut_command(
         out,
     )
     .await
+}
+
+fn parse_agents(value: Option<&String>) -> Vec<String> {
+    value
+        .map(|raw| {
+            raw.split(|c| matches!(c, ',' | ';' | '|'))
+                .flat_map(|segment| segment.split(" and "))
+                .map(|agent| agent.trim().to_string())
+                .filter(|agent| !agent.is_empty())
+                .collect()
+        })
+        .filter(|agents: &Vec<String>| !agents.is_empty())
+        .unwrap_or_default()
+}
+
+fn parse_usize_param(
+    params: &std::collections::HashMap<String, String>,
+    key: &str,
+) -> Option<usize> {
+    params.get(key).and_then(|value| value.parse().ok())
+}
+
+fn parse_u8_param(params: &std::collections::HashMap<String, String>, key: &str) -> Option<u8> {
+    params.get(key).and_then(|value| value.parse().ok())
+}
+
+fn parse_f64_param(params: &std::collections::HashMap<String, String>, key: &str) -> Option<f64> {
+    params.get(key).and_then(|value| value.parse().ok())
+}
+
+fn normalize_channel(value: &str) -> Option<String> {
+    if value.trim().is_empty() {
+        return None;
+    }
+    let mut channel = value.trim().to_string();
+    if !channel.starts_with('#') && !channel.starts_with('@') {
+        channel.insert(0, '#');
+    }
+    Some(channel)
 }

--- a/codex-rs/core/src/agent_interpreter.rs
+++ b/codex-rs/core/src/agent_interpreter.rs
@@ -3,10 +3,34 @@
 //! Parses natural language commands and translates them into agent
 //! names and parameters for execution.
 
-use anyhow::{Context, Result};
+use anyhow::Context;
+use anyhow::Result;
+use once_cell::sync::Lazy;
 use regex::Regex;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
+use serde::Serialize;
 use std::collections::HashMap;
+
+static DEEP_RESEARCH_REGEX: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(
+        r"(?i)^(?:please\s+)?(?:run\s+)?(?:a\s+)?(?:deep[-\s]*research|research\s+report|investigate)(?:\s+on|\s+about)?\s*(?P<topic>.+)?$",
+    )
+    .expect("valid deep research regex")
+});
+
+static ORCHESTRATION_REGEX: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(
+        r"(?i)(?:auto[-\s]*orchestrator|ai\s+orchestration|multi-agent\s+session|coordinate\s+agents)(?:.*?with\s+(?P<agents>[a-z0-9_\-\s,]+))?",
+    )
+    .expect("valid orchestration regex")
+});
+
+static ORCHESTRATION_AGENT_LIST_REGEX: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"(?i)with\s+(?P<agents>[a-z0-9_\-\s,]+)").expect("valid agent capture regex")
+});
+
+static WEBHOOK_TEXT_REGEX: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r#"([^"]+)"#).expect("valid quoted text regex"));
 
 /// Parsed agent invocation from natural language.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -19,6 +43,31 @@ pub struct AgentInvocation {
     pub parameters: HashMap<String, String>,
     /// Confidence score (0.0-1.0)
     pub confidence: f64,
+    /// Action that should be taken for this invocation
+    pub action: AgentAction,
+}
+
+/// High-level action that the interpreter resolved from natural language.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum AgentAction {
+    /// Delegate work to a specific agent.
+    Delegate { agent: String },
+    /// Run the auto-orchestrator / pair programming workflow.
+    AutoOrchestrate,
+    /// Conduct deep research.
+    DeepResearch { use_gemini: bool, use_mcp: bool },
+    /// Trigger a webhook integration.
+    TriggerWebhook { service: WebhookServiceKind },
+    /// List configured MCP tools.
+    ListMcpTools,
+}
+
+/// Supported webhook services for natural language invocation.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum WebhookServiceKind {
+    Slack,
+    Github,
+    Custom,
 }
 
 /// Natural language interpreter for agent commands.
@@ -61,6 +110,10 @@ impl AgentInterpreter {
     pub fn parse(&self, input: &str) -> Result<AgentInvocation> {
         let input_lower = input.to_lowercase();
 
+        if let Some(invocation) = self.try_parse_special_actions(input, &input_lower) {
+            return Ok(invocation);
+        }
+
         // Try each pattern in order of confidence
         for pattern in &self.patterns {
             if let Some(captures) = pattern.regex.captures(&input_lower) {
@@ -81,8 +134,11 @@ impl AgentInterpreter {
                 return Ok(AgentInvocation {
                     agent_name: pattern.agent_name.clone(),
                     goal: input.to_string(),
-                    parameters,
+                    parameters: parameters.clone(),
                     confidence: pattern.confidence,
+                    action: AgentAction::Delegate {
+                        agent: pattern.agent_name.clone(),
+                    },
                 });
             }
         }
@@ -93,7 +149,99 @@ impl AgentInterpreter {
             goal: input.to_string(),
             parameters: HashMap::new(),
             confidence: 0.3,
+            action: AgentAction::Delegate {
+                agent: "code-reviewer".to_string(),
+            },
         })
+    }
+
+    fn try_parse_special_actions(&self, input: &str, input_lower: &str) -> Option<AgentInvocation> {
+        if let Some(caps) = DEEP_RESEARCH_REGEX.captures(input) {
+            let topic = caps
+                .name("topic")
+                .map(|m| m.as_str().trim().to_string())
+                .filter(|topic| !topic.is_empty())
+                .unwrap_or_else(|| input.trim().to_string());
+
+            let mut parameters = HashMap::new();
+            parameters.insert("topic".to_string(), topic.clone());
+
+            let use_gemini = input_lower.contains("gemini");
+            let use_mcp = input_lower.contains("mcp") || input_lower.contains("multi-client");
+
+            return Some(AgentInvocation {
+                agent_name: "deep-research".to_string(),
+                goal: topic,
+                parameters,
+                confidence: 0.9,
+                action: AgentAction::DeepResearch {
+                    use_gemini,
+                    use_mcp,
+                },
+            });
+        }
+
+        if input_lower.contains("mcp") {
+            return Some(AgentInvocation {
+                agent_name: "mcp".to_string(),
+                goal: input.trim().to_string(),
+                parameters: HashMap::new(),
+                confidence: 0.85,
+                action: AgentAction::ListMcpTools,
+            });
+        }
+
+        if input_lower.contains("hook") || input_lower.contains("webhook") {
+            let mut parameters = HashMap::new();
+            if let Some(channel) = extract_channel_name(input) {
+                parameters.insert("channel".to_string(), channel);
+            }
+            let message = extract_webhook_message(input);
+            parameters.insert("message".to_string(), message.clone());
+
+            let service = if input_lower.contains("slack") {
+                WebhookServiceKind::Slack
+            } else if input_lower.contains("github") {
+                WebhookServiceKind::Github
+            } else {
+                WebhookServiceKind::Custom
+            };
+
+            return Some(AgentInvocation {
+                agent_name: format!("{:?}-webhook", service).to_lowercase(),
+                goal: message,
+                parameters,
+                confidence: 0.8,
+                action: AgentAction::TriggerWebhook { service },
+            });
+        }
+
+        if let Some(caps) = ORCHESTRATION_REGEX.captures(input) {
+            let mut parameters = HashMap::new();
+            if let Some(agent_list_match) = ORCHESTRATION_AGENT_LIST_REGEX.captures(input) {
+                if let Some(agent_list) = agent_list_match.name("agents") {
+                    parameters.insert("agents".to_string(), agent_list.as_str().trim().to_string());
+                }
+            }
+
+            if let Some(agent_capture) = caps.name("agents") {
+                parameters.insert(
+                    "agents".to_string(),
+                    agent_capture.as_str().trim().to_string(),
+                );
+            }
+
+            let goal = input.trim().to_string();
+            return Some(AgentInvocation {
+                agent_name: "auto-orchestrator".to_string(),
+                goal,
+                parameters,
+                confidence: 0.92,
+                action: AgentAction::AutoOrchestrate,
+            });
+        }
+
+        None
     }
 
     /// Get default patterns for common agent invocations.
@@ -222,6 +370,12 @@ mod tests {
             .unwrap();
         assert_eq!(result.agent_name, "sec-audit");
         assert!(result.confidence > 0.9);
+        assert_eq!(
+            result.action,
+            AgentAction::Delegate {
+                agent: "sec-audit".to_string()
+            }
+        );
     }
 
     #[test]
@@ -233,6 +387,12 @@ mod tests {
             .unwrap();
         assert_eq!(result.agent_name, "test-gen");
         assert!(result.confidence > 0.8);
+        assert_eq!(
+            result.action,
+            AgentAction::Delegate {
+                agent: "test-gen".to_string()
+            }
+        );
     }
 
     #[test]
@@ -243,6 +403,12 @@ mod tests {
             .parse("Review this file with security focus")
             .unwrap();
         assert_eq!(result.agent_name, "code-reviewer");
+        assert_eq!(
+            result.action,
+            AgentAction::Delegate {
+                agent: "code-reviewer".to_string()
+            }
+        );
     }
 
     #[test]
@@ -253,6 +419,12 @@ mod tests {
             .parse("Research React Server Components best practices")
             .unwrap();
         assert_eq!(result.agent_name, "researcher");
+        assert_eq!(
+            result.action,
+            AgentAction::Delegate {
+                agent: "researcher".to_string()
+            }
+        );
     }
 
     #[test]
@@ -270,6 +442,12 @@ mod tests {
         let result = interpreter.parse("Do something generic").unwrap();
         assert_eq!(result.agent_name, "code-reviewer");
         assert!(result.confidence < 0.5);
+        assert_eq!(
+            result.action,
+            AgentAction::Delegate {
+                agent: "code-reviewer".to_string()
+            }
+        );
     }
 
     #[test]
@@ -282,4 +460,118 @@ mod tests {
         let result = interpreter.parse("Refactor this module").unwrap();
         assert_eq!(result.agent_name, "code-reviewer");
     }
+
+    #[test]
+    fn test_deep_research_detection() {
+        let interpreter = AgentInterpreter::new();
+
+        let result = interpreter
+            .parse("Deep research on Rust security using Gemini and MCP")
+            .unwrap();
+
+        assert_eq!(result.agent_name, "deep-research");
+        assert_eq!(
+            result.parameters.get("topic").unwrap(),
+            "Rust security using Gemini and MCP"
+        );
+        assert_eq!(
+            result.action,
+            AgentAction::DeepResearch {
+                use_gemini: true,
+                use_mcp: true
+            }
+        );
+    }
+
+    #[test]
+    fn test_orchestration_detection() {
+        let interpreter = AgentInterpreter::new();
+
+        let result = interpreter
+            .parse("AI orchestration with agent-alpha, agent-beta for refactor")
+            .unwrap();
+
+        assert_eq!(result.agent_name, "auto-orchestrator");
+        assert_eq!(
+            result.parameters.get("agents").unwrap(),
+            "agent-alpha, agent-beta"
+        );
+        assert_eq!(result.action, AgentAction::AutoOrchestrate);
+    }
+
+    #[test]
+    fn test_webhook_detection() {
+        let interpreter = AgentInterpreter::new();
+
+        let result = interpreter
+            .parse("Send Slack webhook to #alerts: \"Deploy succeeded\"")
+            .unwrap();
+
+        assert_eq!(result.agent_name, "slack-webhook");
+        assert_eq!(result.parameters.get("channel").unwrap(), "#alerts");
+        assert_eq!(
+            result.action,
+            AgentAction::TriggerWebhook {
+                service: WebhookServiceKind::Slack
+            }
+        );
+    }
+
+    #[test]
+    fn test_mcp_detection() {
+        let interpreter = AgentInterpreter::new();
+
+        let result = interpreter
+            .parse("Show me the MCP tools configured for this project")
+            .unwrap();
+
+        assert_eq!(result.agent_name, "mcp");
+        assert_eq!(result.action, AgentAction::ListMcpTools);
+    }
+}
+
+fn extract_channel_name(input: &str) -> Option<String> {
+    let tokens: Vec<&str> = input.split_whitespace().collect();
+    for window in tokens.windows(2) {
+        if window[0].eq_ignore_ascii_case("channel") {
+            if let Some(channel) = clean_channel_token(window[1]) {
+                return Some(channel);
+            }
+        }
+    }
+
+    tokens.iter().find_map(|token| clean_channel_token(token))
+}
+
+fn extract_webhook_message(input: &str) -> String {
+    if let Some(captures) = WEBHOOK_TEXT_REGEX.captures(input) {
+        if let Some(matched) = captures.get(1) {
+            let text = matched.as_str().trim();
+            if !text.is_empty() {
+                return text.to_string();
+            }
+        }
+    }
+
+    if let Some(idx) = input.find(':') {
+        let text = input[idx + 1..].trim();
+        if !text.is_empty() {
+            return text.to_string();
+        }
+    }
+
+    input.trim().to_string()
+}
+
+fn clean_channel_token(token: &str) -> Option<String> {
+    let trimmed = token.trim_matches(|c: char| matches!(c, ',' | ';' | '.' | '!'));
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    if trimmed.starts_with('#') || trimmed.starts_with('@') {
+        return Some(trimmed.to_string());
+    }
+
+    None
 }

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -1215,6 +1215,18 @@ impl ChatWidget {
             SlashCommand::Approvals => {
                 self.open_approvals_popup();
             }
+            SlashCommand::Delegate => {
+                self.add_delegate_info();
+            }
+            SlashCommand::Orchestrate => {
+                self.add_orchestrate_info();
+            }
+            SlashCommand::Research => {
+                self.add_research_info();
+            }
+            SlashCommand::Hook => {
+                self.add_hook_info();
+            }
             SlashCommand::Quit => {
                 self.app_event_tx.send(AppEvent::ExitRequest);
             }
@@ -2040,6 +2052,38 @@ impl ChatWidget {
         } else {
             self.submit_op(Op::ListMcpTools);
         }
+    }
+
+    fn add_delegate_info(&mut self) {
+        let message = "Use natural language or @mentions to delegate work to sub-agents.\nExample: \"Delegate code review to @code-reviewer for src/main.rs\"";
+        let hint = Some("Tip: run `codex agent 'Deep research on Rust security'` from the CLI for the same interpreter.".to_string());
+        self.add_info_message(message.to_string(), hint);
+    }
+
+    fn add_orchestrate_info(&mut self) {
+        let message = "Kick off auto orchestration and supervisor flows.\nExample: \"Auto orchestrate multi-agent session with agent-alpha and agent-beta for release notes\"";
+        let hint = Some(
+            "Runs the pair programming / auto-orchestrator loop via `codex agent`".to_string(),
+        );
+        self.add_info_message(message.to_string(), hint);
+    }
+
+    fn add_research_info(&mut self) {
+        let message = "Launch Deep Research with Gemini or MCP integrations.\nTry: \"Deep research on WebAssembly security using Gemini\"";
+        let hint = Some(
+            "Generates a full research report with citations and saves to artifacts/report.md"
+                .to_string(),
+        );
+        self.add_info_message(message.to_string(), hint);
+    }
+
+    fn add_hook_info(&mut self) {
+        let message = "Trigger webhook integrations like Slack notifications.\nExample: \"Send Slack webhook to #alerts: \"Deploy succeeded\"\"";
+        let hint = Some(
+            "GitHub and custom webhooks are available from the CLI with `codex webhook`"
+                .to_string(),
+        );
+        self.add_info_message(message.to_string(), hint);
     }
 
     /// Forward file-search results to the bottom pane.

--- a/codex-rs/tui/src/slash_command.rs
+++ b/codex-rs/tui/src/slash_command.rs
@@ -15,6 +15,10 @@ pub enum SlashCommand {
     Model,
     Approvals,
     Review,
+    Delegate,
+    Orchestrate,
+    Research,
+    Hook,
     New,
     Init,
     Compact,
@@ -39,6 +43,10 @@ impl SlashCommand {
             SlashCommand::Init => "create an AGENTS.md file with instructions for Codex",
             SlashCommand::Compact => "summarize conversation to prevent hitting the context limit",
             SlashCommand::Review => "review my current changes and find issues",
+            SlashCommand::Delegate => "delegate a task to a sub-agent using natural language",
+            SlashCommand::Orchestrate => "kick off auto orchestration / supervisor flows",
+            SlashCommand::Research => "conduct deep research (Gemini, MCP, web)",
+            SlashCommand::Hook => "trigger webhook integrations (Slack, etc.)",
             SlashCommand::Undo => "ask Codex to undo a turn",
             SlashCommand::Quit => "exit Codex",
             SlashCommand::Diff => "show git diff (including untracked files)",
@@ -69,6 +77,10 @@ impl SlashCommand {
             | SlashCommand::Model
             | SlashCommand::Approvals
             | SlashCommand::Review
+            | SlashCommand::Delegate
+            | SlashCommand::Orchestrate
+            | SlashCommand::Research
+            | SlashCommand::Hook
             | SlashCommand::Logout => false,
             SlashCommand::Diff
             | SlashCommand::Mention


### PR DESCRIPTION
## Summary
- extend the agent interpreter to detect deep research, webhook, MCP, and auto-orchestration intents with structured actions
- add CLI natural-language routing that launches deep research, orchestrator, or webhook flows and surfaces MCP listing via AgentInterpreter
- provide new `/delegate`, `/orchestrate`, `/research`, and `/hook` slash command helpers in the TUI to guide usage

## Testing
- `cargo fmt -p codex-core -p codex-cli -p codex-tui`
- `cargo test -p codex-core` *(fails: repository integration tests reference outdated AgentRuntime::new signature)*
- `cargo test -p codex-tui` *(fails: existing config structs missing required fields in upstream tree)*

------
https://chatgpt.com/codex/tasks/task_e_6902b2d4211083259ff1ba6a70b4215f